### PR TITLE
Publish Android native targets

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -128,7 +128,6 @@ tasks.create("ciTest") {
 tasks.create("ciPublish") {
     ciHostTargets
         .map { it.name.uppercaseFirstChar() }
-        .filter { !it.startsWith("Android") }
         .map { if (it == "Metadata") "KotlinMultiplatform" else it }
         .map { target -> "publish${target}PublicationToMavenRepository" }
         .forEach { publishTarget ->


### PR DESCRIPTION
The removed line was meant to filter out the testing targets, since the Android native targets don't have tests, but it was accidentally added to the ciPublish task. Does not need to be added to the ciTest task since the `KotlinTargetWithTests` filter covers it.