### PR TITLE
Improve failure tooling on jvm with opentest4j

### DIFF
--- a/api/parameterize.api
+++ b/api/parameterize.api
@@ -40,9 +40,11 @@ public abstract interface class com/benwoodworth/parameterize/ParameterizeContex
 	public abstract fun getParameterizeConfiguration ()Lcom/benwoodworth/parameterize/ParameterizeConfiguration;
 }
 
-public final class com/benwoodworth/parameterize/ParameterizeFailedError : java/lang/AssertionError {
+public final class com/benwoodworth/parameterize/ParameterizeFailedError : org/opentest4j/MultipleFailuresError {
 	public static final field Companion Lcom/benwoodworth/parameterize/ParameterizeFailedError$Companion;
+	public synthetic fun getFailures ()Ljava/util/List;
 	public fun getMessage ()Ljava/lang/String;
+	public synthetic fun hasFailures ()Z
 }
 
 public final class com/benwoodworth/parameterize/ParameterizeFailedError$Companion {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,9 +54,7 @@ kotlin {
     targets.configureEach {
         compilations.configureEach {
             compilerOptions.configure {
-                if (name == "test") {
-                    freeCompilerArgs.add("-Xexpect-actual-classes")
-                }
+                freeCompilerArgs.add("-Xexpect-actual-classes")
             }
         }
     }
@@ -70,6 +68,11 @@ kotlin {
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test"))
+            }
+        }
+        val jvmMain by getting {
+            dependencies {
+                implementation("org.opentest4j:opentest4j:1.3.0")
             }
         }
     }

--- a/src/jsMain/kotlin/ParameterizeFailedError.js.kt
+++ b/src/jsMain/kotlin/ParameterizeFailedError.js.kt
@@ -1,5 +1,21 @@
 package com.benwoodworth.parameterize
 
+public actual class ParameterizeFailedError internal actual constructor(
+    internal actual val recordedFailures: List<ParameterizeFailure>,
+    internal actual val failureCount: Long,
+    internal actual val iterationCount: Long,
+    internal actual val completedEarly: Boolean
+) : AssertionError() {
+    public actual companion object;
+
+    init {
+        commonInit()
+    }
+
+    public actual override val message: String
+        get() = commonMessage
+}
+
 internal actual fun Throwable.clearStackTrace() {
     // The `stack` property is non-standard, but supported on all major browsers/servers:
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack#browser_compatibility

--- a/src/jvmMain/kotlin/ParameterizeFailedError.jvm.kt
+++ b/src/jvmMain/kotlin/ParameterizeFailedError.jvm.kt
@@ -1,5 +1,33 @@
 package com.benwoodworth.parameterize
 
+import org.opentest4j.MultipleFailuresError
+
+@Suppress("ACTUAL_WITHOUT_EXPECT") // https://youtrack.jetbrains.com/issue/KT-20641/
+public actual class ParameterizeFailedError internal actual constructor(
+    internal actual val recordedFailures: List<ParameterizeFailure>,
+    internal actual val failureCount: Long,
+    internal actual val iterationCount: Long,
+    internal actual val completedEarly: Boolean
+) : MultipleFailuresError(null, emptyList()) {
+    public actual companion object;
+
+    init {
+        commonInit()
+    }
+
+    public actual override val message: String
+        get() = commonMessage
+
+    // Usually won't be used, so compute as needed (instead of always providing it to `MultipleFailuresError` up front)
+    @Deprecated("Exists for MultipleFailuresError tooling, and is not API", level = DeprecationLevel.HIDDEN)
+    override fun getFailures(): List<Throwable> =
+        recordedFailures.map { it.failure }
+
+    @Deprecated("Exists for MultipleFailuresError tooling, and is not API", level = DeprecationLevel.HIDDEN)
+    override fun hasFailures(): Boolean =
+        recordedFailures.isNotEmpty()
+}
+
 internal actual fun Throwable.clearStackTrace() {
     stackTrace = emptyArray()
 }

--- a/src/jvmTest/kotlin/ParameterizeFailedErrorSpec.jvm.kt
+++ b/src/jvmTest/kotlin/ParameterizeFailedErrorSpec.jvm.kt
@@ -1,0 +1,79 @@
+package com.benwoodworth.parameterize
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.opentest4j.MultipleFailuresError
+import java.lang.reflect.Modifier
+import kotlin.reflect.KClass
+import kotlin.test.Test
+import kotlin.test.fail
+
+class ParameterizeFailedErrorSpecJvm {
+    @Test
+    fun get_failures_should_be_the_undecorated_recorded_failures() {
+        val recordedFailures = (1..5).map {
+            ParameterizeFailure(Throwable("Failure $it"), listOf())
+        }
+
+        val error: MultipleFailuresError = ParameterizeFailedError(
+            recordedFailures,
+            failureCount = recordedFailures.size.toLong(),
+            iterationCount = recordedFailures.size.toLong(),
+            completedEarly = false
+        )
+
+        val expectedFailures = recordedFailures.map { it.failure }
+
+        assertEquals(expectedFailures, error.failures)
+    }
+
+    @Test
+    fun has_failures_should_be_correct() = testAll(
+        "empty" to emptyList(),
+        "non-empty" to listOf(Throwable("Failure"))
+    ) { failures ->
+        val recordedFailures = failures
+            .map { ParameterizeFailure(it, emptyList()) }
+
+        val error: MultipleFailuresError = ParameterizeFailedError(
+            recordedFailures,
+            failureCount = recordedFailures.size.toLong(),
+            iterationCount = recordedFailures.size.toLong(),
+            completedEarly = false
+        )
+
+        assertEquals(failures.isNotEmpty(), error.hasFailures())
+    }
+
+    /**
+     * [MultipleFailuresError] only exists for test tooling so the failures can be listed nicely. The API it provides
+     * isn't desirable though (since this library could provide a richer list of failures), so anything inherited from
+     * it should be suppressed.
+     */
+    @Test
+    fun methods_inherited_from_MultipleFailuresError_should_be_hidden_from_the_API() {
+        fun KClass<*>.inheritableMethods(): List<String> =
+            java.methods
+                .filter { Modifier.isPublic(it.modifiers) }
+                .filterNot { Modifier.isStatic(it.modifiers) }
+                .map { it.name }
+
+        val methodsFromMultipleFailuresError =
+            MultipleFailuresError::class.inheritableMethods() - AssertionError::class.inheritableMethods().toSet()
+
+        testAll(
+            methodsFromMultipleFailuresError.map { it to it }
+        ) { method ->
+            val deprecatedAnnotation = ParameterizeFailedError::class.java
+                .getMethod(method)
+                .annotations
+                .filterIsInstance<Deprecated>()
+                .firstOrNull()
+                ?: fail("No @Deprecated annotation")
+
+            val expectedMessage = "Exists for ${MultipleFailuresError::class.simpleName} tooling, and is not API"
+            assertEquals(expectedMessage, deprecatedAnnotation.message, "message")
+
+            assertEquals(DeprecationLevel.HIDDEN, deprecatedAnnotation.level, "level")
+        }
+    }
+}

--- a/src/nativeMain/kotlin/ParameterizeFailedError.native.kt
+++ b/src/nativeMain/kotlin/ParameterizeFailedError.native.kt
@@ -1,5 +1,21 @@
 package com.benwoodworth.parameterize
 
+public actual class ParameterizeFailedError internal actual constructor(
+    internal actual val recordedFailures: List<ParameterizeFailure>,
+    internal actual val failureCount: Long,
+    internal actual val iterationCount: Long,
+    internal actual val completedEarly: Boolean
+) : AssertionError() {
+    public actual companion object;
+
+    init {
+        commonInit()
+    }
+
+    public actual override val message: String
+        get() = commonMessage
+}
+
 internal actual fun Throwable.clearStackTrace() {
     // Currently not possible on native: https://youtrack.jetbrains.com/issue/KT-59017/
 }


### PR DESCRIPTION
Resolves #13

`ParameterizeFailedError` now extends `MultipleFailuresError`, providing a list of failures that tools can hook into. The listed errors are not decorated with additional parameter argument info, so tools can see the raw errors that were thrown and handle them appropriately.

On IntelliJ, for example, this means each failure from `assertEquals()` and the like will have a "<Click to see difference>" link that pulls up a diff UI for the actual/expected values.