### PR TITLE
Fix `ParameterizeFailedError` not showing parameter names

### DIFF
--- a/parameterize-core/src/commonMain/kotlin/ParameterizeFailedError.kt
+++ b/parameterize-core/src/commonMain/kotlin/ParameterizeFailedError.kt
@@ -63,6 +63,9 @@ internal expect class Failure : AssertionError {
     override val cause: Throwable
 }
 
+private fun ParameterizeScope.DeclaredParameter<*>.toErrorString(): String =
+    "${property.name} = $argument"
+
 @Suppress("NOTHING_TO_INLINE")
 internal inline fun ParameterizeFailedError.Companion.commonShouldCaptureStackTrace(
     recordedFailures: List<ParameterizeFailure>
@@ -111,7 +114,7 @@ internal inline val ParameterizeFailedError.commonMessage
 
                 failure.parameters.forEach { parameter ->
                     append("\n\t\t")
-                    append(parameter.argument)
+                    append(parameter.toErrorString())
                 }
             }
 
@@ -125,14 +128,16 @@ internal inline val Failure.commonMessage: String
     get() = when (failure.parameters.size) {
         0 -> "Failed with no arguments"
 
-        1 -> failure.parameters.single().let { argument ->
-            "Failed with argument:\n\t\t$argument"
+        1 -> failure.parameters.single().let { parameter ->
+            "Failed with argument:\n\t\t${parameter.toErrorString()}"
         }
 
         else -> failure.parameters.joinToString(
             prefix = "Failed with arguments:\n\t\t",
             separator = "\n\t\t"
-        )
+        ) { parameter ->
+            parameter.toErrorString()
+        }
     }
 
 internal inline val Failure.commonCause: Throwable

--- a/parameterize-core/src/commonMain/kotlin/ParameterizeFailedError.kt
+++ b/parameterize-core/src/commonMain/kotlin/ParameterizeFailedError.kt
@@ -26,8 +26,8 @@ import com.benwoodworth.parameterize.ParameterizeConfiguration.OnCompleteScope
  * [completedEarly][OnCompleteScope.completedEarly] was true in [onComplete][Builder.onComplete].
  *
  * The [suppressedExceptions] include [recordedFailures][OnCompleteScope.recordedFailures] from the
- * [onComplete][Builder.onComplete] handler, with each being decorated with a message to include a list of the
- * [arguments][ParameterizeFailure.arguments] that caused it.
+ * [onComplete][Builder.onComplete] handler, each being decorated with a message to include a list of the
+ * [parameter arguments][ParameterizeFailure.parameters] that caused it.
  *
  * Can only be constructed from [onComplete][Builder.onComplete].
  */

--- a/parameterize-core/src/commonTest/kotlin/ParameterizeFailedErrorSpec.kt
+++ b/parameterize-core/src/commonTest/kotlin/ParameterizeFailedErrorSpec.kt
@@ -26,7 +26,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 
 class ParameterizeFailedErrorSpec {
-    private val arguments = run {
+    private val parameters = run {
         val properties = object : Any() {
             val propertyA = "argumentA"
             val propertyB = "argumentB"
@@ -37,9 +37,6 @@ class ParameterizeFailedErrorSpec {
             DeclaredParameter(properties::propertyB, properties.propertyB)
         )
     }
-
-    private val argumentA = arguments[0]
-    private val argumentB = arguments[1]
 
     @Test
     fun message_should_have_failure_count_and_total() {
@@ -194,7 +191,7 @@ class ParameterizeFailedErrorSpec {
         )
 
         val error = ParameterizeFailedError(
-            failures.mapIndexed { index, it -> ParameterizeFailure(it, arguments.take(index)) },
+            failures.mapIndexed { index, it -> ParameterizeFailure(it, parameters.take(index)) },
             successCount = 4,
             failureCount = 3,
             completedEarly = false
@@ -206,10 +203,10 @@ class ParameterizeFailedErrorSpec {
             Failed 3/7 cases
             ${'\t'}${failures[0]::class.simpleName}: Failure 0
             ${'\t'}${failures[1]::class.simpleName}: Failure 1
-            ${'\t'}${'\t'}${arguments[0]}
+            ${'\t'}${'\t'}${parameters[0].property.name} = ${parameters[0].argument}
             ${'\t'}${failures[2]::class.simpleName}: Failure 2
-            ${'\t'}${'\t'}${arguments[0]}
-            ${'\t'}${'\t'}${arguments[1]}
+            ${'\t'}${'\t'}${parameters[0].property.name} = ${parameters[0].argument}
+            ${'\t'}${'\t'}${parameters[1].property.name} = ${parameters[1].argument}
         """.trimIndent()
 
         assertEquals(expectedMessage, error.message)
@@ -220,7 +217,7 @@ class ParameterizeFailedErrorSpec {
         val failures = List(20) { i -> Throwable("Failure $i") }
 
         val error = ParameterizeFailedError(
-            failures.map { ParameterizeFailure(it, arguments) },
+            failures.map { ParameterizeFailure(it, parameters) },
             successCount = 4,
             failureCount = 3,
             completedEarly = false
@@ -249,7 +246,7 @@ class ParameterizeFailedErrorSpec {
     @Test
     fun recorded_failure_message_with_one_used_parameter_should_list_its_argument() {
         val error = ParameterizeFailedError(
-            listOf(ParameterizeFailure(Throwable(), arguments.take(1))),
+            listOf(ParameterizeFailure(Throwable(), parameters.take(1))),
             successCount = 0,
             failureCount = 1,
             completedEarly = false
@@ -260,7 +257,7 @@ class ParameterizeFailedErrorSpec {
         // Double indent, since the suppressed exceptions get an extra level of indentation
         val expectedMessage = """
             Failed with argument:
-            ${"\t\t"}$argumentA
+            ${'\t'}${'\t'}${parameters[0].property.name} = ${parameters[0].argument}
         """.trimIndent()
 
         assertEquals(expectedMessage, augmentedFailure.message)
@@ -269,7 +266,7 @@ class ParameterizeFailedErrorSpec {
     @Test
     fun recorded_failure_message_with_two_used_parameters_should_list_their_arguments() {
         val error = ParameterizeFailedError(
-            listOf(ParameterizeFailure(Throwable(), arguments)),
+            listOf(ParameterizeFailure(Throwable(), parameters)),
             successCount = 0,
             failureCount = 1,
             completedEarly = false
@@ -279,8 +276,8 @@ class ParameterizeFailedErrorSpec {
 
         val expectedMessage = """
             Failed with arguments:
-            ${"\t\t"}$argumentA
-            ${"\t\t"}$argumentB
+            ${'\t'}${'\t'}${parameters[0].property.name} = ${parameters[0].argument}
+            ${'\t'}${'\t'}${parameters[1].property.name} = ${parameters[1].argument}
         """.trimIndent()
 
         assertEquals(expectedMessage, augmentedFailure.message)
@@ -305,7 +302,7 @@ class ParameterizeFailedErrorSpec {
         val failure = Throwable("Failure message")
 
         val error = ParameterizeFailedError(
-            listOf(ParameterizeFailure(failure, arguments)),
+            listOf(ParameterizeFailure(failure, parameters)),
             successCount = 0,
             failureCount = 1,
             completedEarly = false
@@ -320,7 +317,7 @@ class ParameterizeFailedErrorSpec {
         val failure = Throwable("Failure message")
 
         val error = ParameterizeFailedError(
-            listOf(ParameterizeFailure(failure, arguments)),
+            listOf(ParameterizeFailure(failure, parameters)),
             successCount = 0,
             failureCount = 1,
             completedEarly = false


### PR DESCRIPTION
The old `ParameterizeFailure.Argument` class did show
"parameter = argument" in the message, but it was replaced with
`DeclaredParameter` which doesn't include the parameter name in its
string representation.