### PR TITLE
Fix KDoc not picking up the version from CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,10 +37,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: 'Set CI_VERSION'
+      - name: 'Set Gradle project version'
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         shell: bash
-        run: echo "CI_VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
+        run: echo "ORG_GRADLE_PROJECT_version=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
 
       - name: Set up JDK
         uses: actions/setup-java@v4
@@ -70,10 +70,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: 'Set CI_VERSION'
+      - name: 'Set Gradle project version'
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         shell: bash
-        run: echo "CI_VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
+        run: echo "ORG_GRADLE_PROJECT_version=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
 
       - name: Set up JDK
         uses: actions/setup-java@v4

--- a/buildSrc/src/main/kotlin/publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/publishing-conventions.gradle.kts
@@ -19,10 +19,6 @@ plugins {
     id("com.vanniktech.maven.publish")
 }
 
-System.getenv("CI_VERSION")?.let { ciVersion ->
-    version = ciVersion
-}
-
 mavenPublishing {
     publishToMavenCentral()
     signAllPublications()


### PR DESCRIPTION
The `CI_VERSION` environment variable was picked up and set from within publishing-conventions.gradle.kts, but that isn't included in the root project where the KDoc is generated. Because of that, Dokka used the snapshot version that's in the Gradle properties.

Instead of having build scripts pick up and set the version, now the CI sets the project version directly using the `ORG_GRADLE_PROJECT_version` environment variable, overriding the version from the Gradle properties.